### PR TITLE
Added note about wiki/gitcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # CS530
+
+## Checkout the Wiki for help on Git commands


### PR DESCRIPTION
I added a note about the git help page on the wiki I just made. Idk if I can link to it, git links don't work for me in the preview of the markdown.