### PR TITLE
Constructor Fix? Corrected Style for struct getters, outstream scope half fix?

### DIFF
--- a/file_parser.cc
+++ b/file_parser.cc
@@ -144,10 +144,10 @@ ostream &operator<<(ostream &out, const line &value) {
     const int opcode_col_width = 8;
     const int operand_col_width = 8;
 
-    out << setw(label_col_width) << ios::left << setfill(' ') << label;
-    out << setw(opcode_col_width) << ios::left << setfill(' ') << opcode;
-    out << setw(operand_col_width) << ios::left << setfill(' ') << operand_col_width;
-    out << comment << endl;
+    out << setw(label_col_width) << ios::left << setfill(' ') << &line.getlabel();
+    out << setw(opcode_col_width) << ios::left << setfill(' ') << &line.getopcode();
+    out << setw(operand_col_width) << ios::left << setfill(' ') << &line.getoperand();
+    out << &line.getcomment() << endl;
 
     return out;
 }


### PR DESCRIPTION
This fixed the compile error with the constructor. I also corrected the style on the struct getters. I tried to get the oustream functions label/opcode/operand in scope, but c++ pointer syntax alludes me.