### PR TITLE
Created opcodetab.h, should match the .cc

### DIFF
--- a/opcodetab.cc
+++ b/opcodetab.cc
@@ -1,9 +1,10 @@
 #include <iostream>
 #include <map>
-//#include "opcodetab.h"
+#include "opcodetab.h"
 using namespace std;
 
-map <string, pair<string, int>> marvin;
+map <string, pair<string, int> > marvin;
+
 opcodetab::opcodetab() {
 
     string opcode[59] = {"ADD", "ADDF", "ADDR", "AND", "CLEAR", "COMP", "COMPF",

--- a/opcodetab.h
+++ b/opcodetab.h
@@ -41,7 +41,7 @@ class opcodetab {
                         
     private:
         // your variables and private methods go here
-        map<string,pair<string, int>> marvin;
+        map<string,pair<string, int> > marvin;
 
 };
 


### PR DESCRIPTION
Compiles on Edoras, however it complains about an undefined reference to '_start' which I think is just the cause of not using a make file to make it. The big changes in the .cc file was an auto format in CLion after making the scope match the fileparser.cc.