### PR TITLE
Added function to return formatted line

### DIFF
--- a/file_parser.cc
+++ b/file_parser.cc
@@ -348,10 +348,6 @@ int file_parser::size() {
     return static_cast<int>(victor.size());
 }
 
-
-
-
-
-
-
-
+struct file_parser::formatted_line file_parser::get_struct(unsigned int row){
+    return victor.at(row);
+}

--- a/file_parser.h
+++ b/file_parser.h
@@ -17,6 +17,33 @@
 
 class file_parser {
 public:
+    struct formatted_line {
+        //Fields
+        std::string label;
+        std::string opcode;
+        std::string operand;
+        std::string comment;
+        std::string address;
+        std::string machinecode;
+        unsigned int linenum;
+        //Methods
+        inline formatted_line() {
+            label = "";
+            opcode = "";
+            operand = "";
+            comment = "";
+            address = "";
+            machinecode = "";
+            linenum = 0;
+        }
+        std::string getlabel() const;
+        std::string getopcode() const;
+        std::string getoperand() const;
+        std::string getcomment() const;
+        std::string getaddress() const;
+        std::string getmachinecode() const;
+        unsigned int getlinenum();
+    };
     // ctor, filename is the parameter.  A driver program will read
     // the filename from the command line, and pass the filename to
     // the file_parser constructor.  Filenames must not be hard-coded.
@@ -47,35 +74,13 @@ public:
     // returns the number of lines in the source code file
     int size();
 
-private:
+    struct formatted_line get_struct(unsigned int);
+
     // your variables and private methods go here
-    struct formatted_line {
-        //Fields
-        std::string label;
-        std::string opcode;
-        std::string operand;
-        std::string comment;
-        std::string address;
-        std::string machinecode;
-        unsigned int linenum;
-        //Methods
-        inline formatted_line() {
-        label = "";
-        opcode = "";
-        operand = "";
-        comment = "";
-        address = "";
-        machinecode = "";
-        linenum = 0;
-    	}
-        std::string getlabel() const;
-        std::string getopcode() const;
-        std::string getoperand() const;
-        std::string getcomment() const;
-        std::string getaddress() const;
-        std::string getmachinecode() const;
-        unsigned int getlinenum();
-    };
+
+
+
+private:
     //Class Level Variables
     std::vector<formatted_line> victor;
     std::vector<std::string> file_contents;


### PR DESCRIPTION
Had to make the struct public in the header to allow the driver to access it.  Should be proper practice? Had to also declare/inline the struct before the function so just put it on the top.

sicxe_asm.cpp can then have stuff like this:

```
file_parser::formatted_line temp;
temp = parser.get_struct(9);
print(temp);
temp.label = something;
print(temp);
```
Copying into a new vector from file_parser would be something like this

```
unsigned int size = parser.size();
vector<file_parser::formatted_line> victor(size);
for(i = 0; i < size ; i++){
    victor.pushback(parser.get_struct(i));
}
```


However the outstream operator for the struct will not print out the full struct++ to the console, just what was needed in prog1. I think this should stay this way because I don't think structs will be printed to the screen in prog3/4.