### PR TITLE
Added Skeleton to Second Pass Method

### DIFF
--- a/sicxe_asm.cpp
+++ b/sicxe_asm.cpp
@@ -293,27 +293,28 @@ void sicxe_asm::do_second_pass() {
     ; //Silences warning for no body while loop
 
         while (line_iter != listing_vector->end() && sicxe_asm::to_uppercase(line_iter->opcode) != "END") {
-        //TODO: Handle Byte/Word Directives
-        // Check formats
-        int format = get_format(line_iter->opcode);
-
-        if (format == 1)
-            handle_format_one();
-        else if (format == 2) {
-            // Handle format 2
-        }
-        else if (format == 3) {
-            // Handle format 3
-        }
-        else if (format == 4) {
-            // Handle format 4
-        }
-        else {
-          //  cout << "ERROR - Format type not detected on line ";
-            //cout << line_iter->linenum << endl;
-            //exit(12);
-        }
-
+            if(line_iter->opcode == ""){
+                //Do Nothing
+            } else if (is_assembler_directive(to_uppercase(line_iter->opcode))){
+                //Handle Byte/Word Directives
+            } else {
+                // Check formats
+                int format = get_format(line_iter->opcode);
+                if (format == 1)
+                    handle_format_one();
+                else if (format == 2) {
+                    // Handle format 2
+                } else if (format == 3) {
+                    // Handle format 3
+                } else if (format == 4) {
+                    // Handle format 4
+                } else {
+                    //TODO: Try/Catch in assemble() should handle this?
+                    //  cout << "ERROR - Format type not detected on line ";
+                    //cout << line_iter->linenum << endl;
+                    //exit(12);
+                }
+            }
         line_iter++; //Grab next line and continue
     }
 
@@ -355,13 +356,13 @@ void sicxe_asm::write_listing_file() {
 void sicxe_asm::assemble() {
     try {
         do_first_pass();
-       // do_second_pass();
+        do_second_pass();
         write_listing_file();
     } catch (file_parse_exception error) {
         cout << "ERROR: " << error.getMessage() << endl;
         exit(9);
     } catch (opcode_error_exception error) {
-        cout << "ERROR: " << error.getMessage() << endl;
+        cout << "ERROR: On Line: " << line_iter->linenum << " " << error.getMessage() << endl;
         exit(8);
     } catch (symtab_exception error) {
         cout << "ERROR: " << error.getMessage() << endl;

--- a/sicxe_asm.h
+++ b/sicxe_asm.h
@@ -137,12 +137,16 @@ inline std::ofstream &operator<<(std::ofstream &out, const file_parser::formatte
     const int address_col_width = 7;
     const int label_col_width = 10;
     const int opcode_col_width = 11;
+    const int operand_col_width = 12;
+    int machine_code = f_l.machinecode;
 
     out << std::setw(linenum_col_width) << std::right << std::setfill(' ') << f_l.linenum << "     ";
     out << std::setw(address_col_width) << std::right << std::setfill(' ') << f_l.address << "     ";
     out << std::setw(label_col_width) << std::left << std::setfill(' ') << f_l.label;
     out << std::setw(opcode_col_width) << std::left << std::setfill(' ') << f_l.opcode;
-    out << f_l.operand << std::endl;
+    out << std::setw(operand_col_width) << std::left << std::setfill(' ') << f_l.operand;
+    //If it's 0 -> print "" if not print hex version
+    out << ( machine_code == 0 ? "" : sicxe_asm::int_to_hex(machine_code, 8)) << std::endl;
 
     return out;
 }


### PR DESCRIPTION
* No longer throws exception on assembler directives or empty strings. 

* If opcode table now throws an exception we grab the line number for the error.

* Outstream operator now prints a (hopefully, only tested format 1) properly formatted machine code or nothing if value is 0 (think this should only be if there is no machine code).

> Outstream operator uses a ternary for using an empty string if machine code == 0
> Compiled, and tested on MBP; Compiled and Ran, but not tested on  😁