### PR TITLE
Fixes The Length of Machine Code in Listing File to Match Format Length

### DIFF
--- a/sicxe_asm.h
+++ b/sicxe_asm.h
@@ -148,7 +148,7 @@ inline std::ofstream &operator<<(std::ofstream &out, const file_parser::formatte
     out << std::setw(opcode_col_width) << std::left << std::setfill(' ') << f_l.opcode;
     out << std::setw(operand_col_width) << std::left << std::setfill(' ') << f_l.operand;
     //If it's 0 -> print "" if not print hex version
-    out << ( machine_code == 0 ? "" : sicxe_asm::int_to_hex(machine_code, 8)) << std::endl;
+    out << ( machine_code == 0 ? "" : sicxe_asm::int_to_hex(machine_code, 2)) << std::endl;
 
     return out;
 }


### PR DESCRIPTION
> ie 00[Format Three] to [Format Three]
> Tested on MBP and Edoras